### PR TITLE
LDP-967: Adding missing 'core_version_requirement: ^8 || ^9' parameter

### DIFF
--- a/modules/sse_dynamic_monthly/sse_dynamic_monthly.info.yml
+++ b/modules/sse_dynamic_monthly/sse_dynamic_monthly.info.yml
@@ -3,6 +3,7 @@ name: Dynamic Monthly Simple Sitemap
 description: 'Adds monthly type to simple XML sitemap.'
 package: SEO
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - drunomics:simple_sitemap_extensions
   - simple_sitemap:simple_sitemap

--- a/simple_sitemap_extensions.info.yml
+++ b/simple_sitemap_extensions.info.yml
@@ -3,5 +3,6 @@ name: Simple XML Sitemap Extensions
 description: 'Extensions for the Simple XML Sitemap module.'
 package: SEO
 core: 8.x
+core_version_requirement: ^8 || ^9
 dependencies:
   - simple_sitemap:simple_sitemap


### PR DESCRIPTION
LDP-967: Adding missing 'core_version_requirement: ^8 || ^9' parameter to info files to make module D9 compatible